### PR TITLE
Always use the computed business day offset in the returned timestamp.

### DIFF
--- a/lib/business-days.rb
+++ b/lib/business-days.rb
@@ -33,16 +33,10 @@ class BusinessDaysSingleton
   #
   # @param days [Integer] how many business days to add to given time.
   # @param time [Time] the start time in UTC from which the business days will be added.
-  # @param reference [Time] the reference time in UTC from which we will compute daylight saving.
   # @return [Time] the computed business day in UTC time (at midnight in Brasilia time)
-  def business_days_from_utc_time(days, time, reference=nil)
-    # Set reference to given time if no reference is passed
-    if reference.nil?
-      reference = time
-    end
-
+  def business_days_from_utc_time(days, time)
     # Get offset from reference data (based on Brasilia timezone)
-    offset = reference.in_time_zone('Brasilia').formatted_offset()
+    offset = time.in_time_zone('Brasilia').formatted_offset()
 
     # Get date from time in reference offset
     date = (time + offset.to_i.hours).to_date
@@ -50,7 +44,10 @@ class BusinessDaysSingleton
     # Add days until we reach the specified business days
     count = 0
     while count < days
-      date += 1.days
+      time += 24*60*60
+
+      offset = time.in_time_zone('Brasilia').formatted_offset()
+      date = (time + offset.to_i.hours).to_date
       if business_day?(date)
         count +=1
       end

--- a/spec/business_days_from_utc_time_spec.rb
+++ b/spec/business_days_from_utc_time_spec.rb
@@ -2,61 +2,65 @@ require_relative '../lib/business-days'
 
 describe 'test' do
   it '2018-01-02 plus 1 business days should be 2018-02-03' do
-    # Reference data is in DST (-02:00)
-    reference = Time.parse('2018-01-02T02:50:00Z')
-
     # This date, in Brasilia time, will be 2018-03-02 (-02:00)
     time = Time.parse('2018-01-02T02:50:00Z')
 
-    expect(BusinessDays.business_days_from_utc_time(1, time, reference)).to eql(Time.parse('2018-01-03T02:00:00Z'))
+    expect(BusinessDays.business_days_from_utc_time(1, time)).to eql(Time.parse('2018-01-03T02:00:00Z'))
   end
 
   it '2018-03-01 plus 1 business days should be 2018-03-02' do
-    # Reference data is not in DST (-03:00)
-    reference = Time.parse('2018-03-02T02:50:00Z')
-
     # This date, in Brasilia time, will be 2018-03-01 (-03:00)
     time = Time.parse('2018-03-02T02:50:00Z')
 
-    expect(BusinessDays.business_days_from_utc_time(1, time, reference)).to eql(Time.parse('2018-03-02T03:00:00Z'))
+    expect(BusinessDays.business_days_from_utc_time(1, time)).to eql(Time.parse('2018-03-02T03:00:00Z'))
   end
 
   it '2018-01-04 plus 5 business days should be 2018-01-11' do
-    # Reference data is in DST (-02:00)
-    reference = Time.parse('2018-01-04T15:00:00Z')
-
     # This date, in Brasilia time, will be 2018-01-04 (-02:00)
     time = Time.parse('2018-01-04T15:00:00Z')
 
-    expect(BusinessDays.business_days_from_utc_time(5, time, reference)).to eql(Time.parse('2018-01-11T02:00:00Z'))
+    expect(BusinessDays.business_days_from_utc_time(5, time)).to eql(Time.parse('2018-01-11T02:00:00Z'))
   end
 
   it '2018-04-30 plus 2 business days should be 2018-05-03' do
-    # Reference data is not in DST (-03:00)
-    reference = Time.parse('2018-04-30T15:00:00Z')
-
     # This date, in Brasilia time, will be 2018-04-30 (-03:00)
     time = Time.parse('2018-04-30T15:00:00Z')
 
-    expect(BusinessDays.business_days_from_utc_time(2, time, reference)).to eql(Time.parse('2018-05-03T03:00:00Z'))
+    expect(BusinessDays.business_days_from_utc_time(2, time)).to eql(Time.parse('2018-05-03T03:00:00Z'))
   end
 
   it '2018-04-26 plus 10 business days should be 2018-05-11' do
-    # Reference data will not be in DST (-03:00). Will be set from given time.
-
     # This date, in Brasilia time, will be 2018-04-26 (-03:00)
     time = Time.parse('2018-04-26T15:00:00Z')
 
     expect(BusinessDays.business_days_from_utc_time(10, time)).to eql(Time.parse('2018-05-11T03:00:00Z'))
   end
 
-  it '2018-04-26 plus 10 business days should be 2018-05-11' do
-    # Reference data is in DST (-02:00)
-    reference = Time.parse('2018-01-01T15:00:00Z')
+  it '2018-11-02 plus 1 business days should be 2018-11-05' do
+    # This date, in Brasilia time, will be 2018-11-02 (-03:00)
+    time = Time.parse('2018-11-02T15:00:00Z')
 
-    # This date, in Brasilia time, will be 2018-04-26 (-02:00)
-    time = Time.parse('2018-04-26T02:50:00Z')
+    expect(BusinessDays.business_days_from_utc_time(1, time)).to eql(Time.parse('2018-11-05T02:00:00Z'))
+  end
 
-    expect(BusinessDays.business_days_from_utc_time(10, time, reference)).to eql(Time.parse('2018-05-11T02:00:00Z'))
+  it '2018-11-03 plus 1 business days should be 2018-11-05' do
+    # This date, in Brasilia time, will be 2018-11-03 (-03:00)
+    time = Time.parse('2018-11-03T15:00:00Z')
+
+    expect(BusinessDays.business_days_from_utc_time(1, time)).to eql(Time.parse('2018-11-05T02:00:00Z'))
+  end
+
+  it '2018-11-04 plus 1 business days should be 2018-11-05' do
+    # This date, in Brasilia time, will be 2018-11-04 (-03:00)
+    time = Time.parse('2018-11-04T15:00:00Z')
+
+    expect(BusinessDays.business_days_from_utc_time(1, time)).to eql(Time.parse('2018-11-05T02:00:00Z'))
+  end
+
+  it '2018-11-05 plus 1 business days should be 2018-11-05' do
+    # This date, in Brasilia time, will be 2018-11-05 (-03:00)
+    time = Time.parse('2018-11-05T15:00:00Z')
+
+    expect(BusinessDays.business_days_from_utc_time(1, time)).to eql(Time.parse('2018-11-06T02:00:00Z'))
   end
 end


### PR DESCRIPTION
Fix #11.